### PR TITLE
Composer cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "5.*"
+        "phpunit/phpunit": "^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -36,5 +36,5 @@
     },
     "config": {
         "sort-packages": true
-  }
+    }
 }


### PR DESCRIPTION
- PHP7.1 by default, push forward!
- Any reason why we're using an asterisk for PHPUnit?