### PR TITLE
Update test-coverage script phpunit path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit",
-        "test-coverage": "phpunit --coverage-html coverage"
+        "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
 
     },
     "config": {


### PR DESCRIPTION
Fixes the `test-coverage` script to use vendor installed `phpunit` rather than from the host system.