### PR TITLE
Replacement of unnecessary package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.3"
     },
     "require-dev": {
-        "larapack/dd": "^1.0",
+        "symfony/var-dumper": "^4.3",
         "phpunit/phpunit": "^8.2"
     },
     "autoload": {


### PR DESCRIPTION
As you can [see](https://github.com/larapack/dd/blob/master/src/helper.php#L3), **larapack/dd** just adds a helper function, but in the latest versions of **symfony/var-dumper** it already is, so we don't need this package